### PR TITLE
cmake add namespace to doc if not main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(NAMESPACE "${PROJECT_NAME}::")
 # generate the library and install instructions
 add_subdirectory(src/lib)
 
+# documentation
 add_subdirectory(doc EXCLUDE_FROM_ALL)
 
 # testing

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,10 +1,16 @@
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+    set(doc doc)
+else()
+    set(doc ${NAMESPACE}doc)
+endif()
+
 find_program(ford_exe NAMES ford)
 
 if(ford_exe)
     set(DOC_DIR "${PROJECT_BINARY_DIR}/doc")
     set(ford_config "main_page.md")
 
-    add_custom_target(doc
+    add_custom_target(${doc}
         COMMAND ${ford_exe} -o ${DOC_DIR} ${ford_config}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )


### PR DESCRIPTION
I only now realized (trying my FLAP config with the new commits) that it is not very intelligent to always create the doc target, it may conflict with a target named the same way in a main project, when the project is included with add_subdirectory, so there is an other check included.