### PR TITLE
change _R16P macro to _real128

### DIFF
--- a/src/lib/penf.F90
+++ b/src/lib/penf.F90
@@ -16,7 +16,7 @@ save
 ! global parameters and variables
 public :: endianL, endianB, endian, is_initialized
 public :: ASCII, UCS4, CK
-#if defined _R16P
+#if defined _real128
 public :: R16P, FR16P, DR16P, MinR16P, MaxR16P, BIR16P, BYR16P, smallR16P, ZeroR16P
 #endif
 public :: R8P,  FR8P,  DR8P,  MinR8P,  MaxR8P,  BIR8P,  BYR8P,  smallR8P,  ZeroR8P
@@ -131,7 +131,7 @@ contains
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  UCS4:  '//str(n=UCS4)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  CK:    '//str(n=CK)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'Reals kind, format and characters number:'
-#if defined _R16P
+#if defined _real128
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  R16P: '//str(n=R16P)//','//FR16P//','//str(n=DR16P)
 #endif
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  R8P:  '//str(n=R8P )//','//FR8P //','//str(n=DR8P )
@@ -143,7 +143,7 @@ contains
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  I2P:  '//str(n=I2P)//','//FI2P //','//str(n=DI2P)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  I1P:  '//str(n=I1P)//','//FI1P //','//str(n=DI1P)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'Reals minimum and maximum values:'
-#if defined _R16P
+#if defined _real128
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  R16P: '//str(n=MinR16P)//','//str(n=MaxR16P)
 #endif
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  R8P:  '//str(n=MinR8P )//','//str(n=MaxR8P )
@@ -155,7 +155,7 @@ contains
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  I2P:  '//str(n=MinI2P )//','//str(n=MaxI2P)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  I1P:  '//str(n=MinI1P )//','//str(n=MaxI1P)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'Reals bits/bytes sizes:'
-#if defined _R16P
+#if defined _real128
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  R16P: '//str(n=BIR16P)//'/'//str(n=BYR16P)
 #endif
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  R8P:  '//str(n=BIR8P )//'/'//str(n=BYR8P )
@@ -167,14 +167,14 @@ contains
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  I2P:  '//str(n=BII2P)//'/'//str(n=BYI2P)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  I1P:  '//str(n=BII1P)//'/'//str(n=BYI1P)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'Smallest reals'
-#if defined _R16P
+#if defined _real128
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  smallR16P: '//str(smallR16P, .true.)
 #endif
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  smallR8P:  '//str(smallR8P,  .true.)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  smallR4P:  '//str(smallR4P,  .true.)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  smallR_P:  '//str(smallR_P,  .true.)
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'Machine zero'
-#if defined _R16P
+#if defined _real128
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  ZeroR16P: '//str(ZeroR16P, .true.)
 #endif
    write(unit=unit,fmt='(A)',iostat=iostatd,iomsg=iomsgd)  prefd//'  ZeroR8P:  '//str(ZeroR8P,  .true.)

--- a/src/lib/penf_b_size.F90
+++ b/src/lib/penf_b_size.F90
@@ -12,7 +12,7 @@ public :: bit_size, byte_size
 interface bit_size
   !< Overloading of the intrinsic *bit_size* function for computing the number of bits of (also) real and character variables.
   module procedure                &
-#if defined _R16P
+#if defined _real128
                    bit_size_R16P, &
 #endif
                    bit_size_R8P,  &
@@ -27,7 +27,7 @@ interface byte_size
                    byte_size_I4P,  &
                    byte_size_I2P,  &
                    byte_size_I1P,  &
-#if defined _R16P
+#if defined _real128
                    byte_size_R16P, &
 #endif
                    byte_size_R8P,  &
@@ -36,7 +36,7 @@ interface byte_size
 endinterface
 
 contains
-#if defined _R16P
+#if defined _real128
    elemental function bit_size_R16P(i) result(bits)
    !< Compute the number of bits of a real variable.
    !<
@@ -98,7 +98,7 @@ contains
    bits = size(transfer(i, mold), dim=1, kind=I4P) * 8_I4P
    endfunction bit_size_chr
 
-#if defined _R16P
+#if defined _real128
    elemental function byte_size_R16P(i) result(bytes)
    !< Compute the number of bytes of a real variable.
    !<

--- a/src/lib/penf_global_parameters_variables.F90
+++ b/src/lib/penf_global_parameters_variables.F90
@@ -33,12 +33,12 @@ integer, parameter :: CK  = UCS4                              !< Default kind ch
 integer, parameter :: CK  = selected_char_kind('default')     !< Default kind character.
 #endif
 
-#if defined _R16P
+#if defined _real128
 integer, parameter :: R16P = selected_real_kind(33,4931) !< 33 digits, range \([10^{-4931}, 10^{+4931} - 1]\); 128 bits.
 #endif
 integer, parameter :: R8P  = selected_real_kind(15,307)  !< 15 digits, range \([10^{-307} , 10^{+307}  - 1]\); 64 bits.
 integer, parameter :: R4P  = selected_real_kind(6,37)    !< 6  digits, range \([10^{-37}  , 10^{+37}   - 1]\); 32 bits.
-#if defined _R16P
+#if defined _real128
 #if defined _R_P_IS_R16P
 integer, parameter :: R_P  = R16P                        !< Default real precision.
 #endif
@@ -58,12 +58,12 @@ integer, parameter :: I1P = selected_int_kind(2)  !< Range \([-2^{7} ,+2^{7}  - 
 integer, parameter :: I_P = I4P                   !< Default integer precision.
 
 ! format parameters
-#if defined _R16P
+#if defined _real128
 character(*), parameter :: FR16P = '(E42.33E4)' !< Output format for kind=R16P real.
 #endif
 character(*), parameter :: FR8P  = '(E23.15E3)' !< Output format for kind=R8P real.
 character(*), parameter :: FR4P  = '(E13.6E2)'  !< Output format for kind=R4P real.
-#if defined _R16P
+#if defined _real128
 #if defined _R_P_IS_R16P
 character(*), parameter :: FR_P  = FR16P        !< Output format for kind=R_P real.
 #endif
@@ -88,12 +88,12 @@ character(*), parameter :: FI_P   = FI4P       !< Output format for kind=I_P int
 character(*), parameter :: FI_PZP = FI4PZP     !< Output format for kind=I_P integer with zero prefixing.
 
 ! length (number of digits) of formatted numbers
-#if defined _R16P
+#if defined _real128
 integer, parameter :: DR16P = 42    !< Number of digits of output format FR16P.
 #endif
 integer, parameter :: DR8P  = 23    !< Number of digits of output format FR8P.
 integer, parameter :: DR4P  = 13    !< Number of digits of output format FR4P.
-#if defined _R16P
+#if defined _real128
 #if defined _R_P_IS_R16P
 integer, parameter :: DR_P  = DR16P !< Number of digits of output format FR_P.
 #endif
@@ -114,12 +114,12 @@ integer, parameter :: DI_P  = DI4P !< Number of digits of output format I_P.
 
 ! list of kinds
 integer,      parameter :: CHARACTER_KINDS_LIST(1:3) = [ASCII, UCS4, CK]                        !< List of character kinds.
-#if defined _R16P
+#if defined _real128
 integer,      parameter :: REAL_KINDS_LIST(1:4)      = [R16P, R8P, R4P, R_P]                    !< List of real kinds.
 #else
 integer,      parameter :: REAL_KINDS_LIST(1:3)      = [R8P, R4P, R_P]                    !< List of real kinds.
 #endif
-#if defined _R16P
+#if defined _real128
 character(*), parameter :: REAL_FORMATS_LIST(1:4)    = [FR16P, FR8P, FR4P//' ', FR_P]           !< List of real formats.
 #else
 character(*), parameter :: REAL_FORMATS_LIST(1:3)    = [FR8P, FR4P//' ', FR_P]           !< List of real formats.
@@ -128,7 +128,7 @@ integer,      parameter :: INTEGER_KINDS_LIST(1:5)   = [I8P, I4P, I2P, I1P,I_P] 
 character(*), parameter :: INTEGER_FORMATS_LIST(1:5) = [FI8P, FI4P, FI2P//' ', FI1P//' ', FI_P] !< List of integer formats.
 
 ! minimum and maximum (representable) values
-#if defined _R16P
+#if defined _real128
 real(R16P),   parameter :: MinR16P = -huge(1._R16P) !< Minimum value of kind=R16P real.
 real(R16P),   parameter :: MaxR16P =  huge(1._R16P) !< Maximum value of kind=R16P real.
 #endif
@@ -150,7 +150,7 @@ integer(I1P), parameter :: MaxI1P  =  huge(1_I1P)   !< Maximum value of kind=I1P
 integer(I_P), parameter :: MaxI_P  =  huge(1_I_P)   !< Maximum value of kind=I_P integer.
 
 ! real smallest (representable) values
-#if defined _R16P
+#if defined _real128
 real(R16P), parameter :: smallR16P = tiny(1._R16P) !< Smallest representable value of kind=R16P real.
 #endif
 real(R8P),  parameter :: smallR8P  = tiny(1._R8P ) !< Smallest representable value of kind=R8P real.
@@ -158,7 +158,7 @@ real(R4P),  parameter :: smallR4P  = tiny(1._R4P ) !< Smallest representable val
 real(R_P),  parameter :: smallR_P  = tiny(1._R_P ) !< Smallest representable value of kind=R_P real.
 
 ! smallest real representable difference by the running calculator
-#if defined _R16P
+#if defined _real128
 real(R16P), parameter :: ZeroR16P = nearest(1._R16P, 1._R16P) - &
                                     nearest(1._R16P,-1._R16P) !< Smallest representable difference of kind=R16P real.
 #endif
@@ -170,13 +170,13 @@ real(R_P),  parameter :: ZeroR_P  = nearest(1._R_P, 1._R_P) - &
                                     nearest(1._R_P,-1._R_P)   !< Smallest representable difference of kind=R_P real.
 
 ! bits/bytes memory requirements
-#if defined _R16P
+#if defined _real128
 integer(I2P), parameter :: BIR16P = storage_size(MaxR16P)      !< Number of bits of kind=R16P real.
 #endif
 integer(I1P), parameter :: BIR8P  = storage_size(MaxR8P)       !< Number of bits of kind=R8P real.
 integer(I1P), parameter :: BIR4P  = storage_size(MaxR4P)       !< Number of bits of kind=R4P real.
 integer(I1P), parameter :: BIR_P  = storage_size(MaxR_P)       !< Number of bits of kind=R_P real.
-#if defined _R16P
+#if defined _real128
 integer(I2P), parameter :: BYR16P = BIR16P/8_I2P               !< Number of bytes of kind=R16P real.
 #endif
 integer(I1P), parameter :: BYR8P  = BIR8P/8_I1P                !< Number of bytes of kind=R8P real.

--- a/src/lib/penf_stringify.F90
+++ b/src/lib/penf_stringify.F90
@@ -38,7 +38,7 @@ endinterface
 interface str
   !< Convert number (real and integer) to string (number to string type casting).
   module procedure                       &
-#if defined _R16P
+#if defined _real128
                    strf_R16P,str_R16P,   &
 #endif
                    strf_R8P ,str_R8P,    &
@@ -48,7 +48,7 @@ interface str
                    strf_I2P ,str_I2P,    &
                    strf_I1P ,str_I1P,    &
                              str_bol,    &
-#if defined _R16P
+#if defined _real128
                              str_a_R16P, &
 #endif
                              str_a_R8P,  &
@@ -67,7 +67,7 @@ endinterface
 interface cton
   !< Convert string to number (real and integer, string to number type casting).
   module procedure            &
-#if defined _R16P
+#if defined _real128
                    ctor_R16P, &
 #endif
                    ctor_R8P,  &
@@ -81,7 +81,7 @@ endinterface
 interface bstr
   !< Convert number (real and integer) to bit-string (number to bit-string type casting).
   module procedure            &
-#if defined _R16P
+#if defined _real128
                    bstr_R16P, &
 #endif
                    bstr_R8P,  &
@@ -95,7 +95,7 @@ endinterface
 interface bcton
   !< Convert bit-string to number (real and integer, bit-string to number type casting).
   module procedure             &
-#if defined _R16P
+#if defined _real128
                    bctor_R16P, &
 #endif
                    bctor_R8P,  &
@@ -203,7 +203,7 @@ contains
    output = input
    endfunction str_ucs4_ucs4
 
-#if defined _R16P
+#if defined _real128
    elemental function strf_R16P(fm, n) result(str)
    !< Convert real to string.
    !<
@@ -310,7 +310,7 @@ contains
    write(str, trim(fm)) n
    endfunction strf_I1P
 
-#if defined _R16P
+#if defined _real128
    elemental function str_R16P(n, no_sign, compact) result(str)
    !< Convert real to string.
    !<
@@ -521,7 +521,7 @@ contains
    write(str, '(L1)') n
    endfunction str_bol
 
-#if defined _R16P
+#if defined _real128
    pure function str_a_R16P(n, no_sign, separator, delimiters, compact) result(str)
    !< Converting real array to string.
    !<
@@ -1050,7 +1050,7 @@ contains
    if (present(nz_pad)) str=str(DI1P-nz_pad:DI1P-1) ! Leaving out the extra zeros padding
    endfunction strz_I1P
 
-#if defined _R16P
+#if defined _real128
    function ctor_R16P(str, knd, pref, error) result(n)
    !< Convert string to real.
    !<
@@ -1220,7 +1220,7 @@ contains
    if (present(error)) error = err
    endfunction ctoi_I1P
 
-#if defined _R16P
+#if defined _real128
    elemental function bstr_R16P(n) result(bstr)
    !< Convert real to string of bits.
    !<
@@ -1342,7 +1342,7 @@ contains
    write(bstr, '(B8.8)') n
    endfunction bstr_I1P
 
-#if defined _R16P
+#if defined _real128
    elemental function bctor_R16P(bstr, knd) result(n)
    !< Convert bit-string to real.
    !<

--- a/src/tests/penf_b_size/penf_b_size-doctest-1.f90
+++ b/src/tests/penf_b_size/penf_b_size-doctest-1.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_b_size
  use penf

--- a/src/tests/penf_b_size/penf_b_size-doctest-5.f90
+++ b/src/tests/penf_b_size/penf_b_size-doctest-5.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_b_size
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-14.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-14.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-15.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-15.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-16.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-16.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-32.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-32.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-33.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-33.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-34.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-34.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-35.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-35.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-36.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-36.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-7.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-7.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-71.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-71.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-78.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-78.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf

--- a/src/tests/penf_stringify/penf_stringify-doctest-85.f90
+++ b/src/tests/penf_stringify/penf_stringify-doctest-85.f90
@@ -1,4 +1,4 @@
-#if defined _R16P
+#if defined _real128
 program volatile_doctest
 use penf_stringify
  use penf


### PR DESCRIPTION
In order to make the macro definition more descriptive and closer to iso_fortran_env, I modified _R16P with _real128