### PR TITLE
change _R16P macro to _real128

### DIFF
--- a/src/lib/penf_b_size.F90
+++ b/src/lib/penf_b_size.F90
@@ -12,7 +12,7 @@ public :: bit_size, byte_size
 interface bit_size
   !< Overloading of the intrinsic *bit_size* function for computing the number of bits of (also) real and character variables.
   module procedure                &
-#if defined _R16P
+#if defined _real128
                    bit_size_R16P, &
 #endif
                    bit_size_R8P,  &
@@ -27,7 +27,7 @@ interface byte_size
                    byte_size_I4P,  &
                    byte_size_I2P,  &
                    byte_size_I1P,  &
-#if defined _R16P
+#if defined _real128
                    byte_size_R16P, &
 #endif
                    byte_size_R8P,  &

--- a/src/lib/penf_global_parameters_variables.F90
+++ b/src/lib/penf_global_parameters_variables.F90
@@ -33,14 +33,14 @@ integer, parameter :: CK  = UCS4                              !< Default kind ch
 integer, parameter :: CK  = selected_char_kind('default')     !< Default kind character.
 #endif
 
-#if defined _R16P
+#if defined _real128
 integer, parameter :: R16P = selected_real_kind(33,4931) !< 33 digits, range \([10^{-4931}, 10^{+4931} - 1]\); 128 bits.
 #else
 integer, parameter :: R16P = selected_real_kind(15,307)  !< 15 digits, range \([10^{-307} , 10^{+307}  - 1]\); 64 bits.
 #endif
 integer, parameter :: R8P  = selected_real_kind(15,307)  !< 15 digits, range \([10^{-307} , 10^{+307}  - 1]\); 64 bits.
 integer, parameter :: R4P  = selected_real_kind(6,37)    !< 6  digits, range \([10^{-37}  , 10^{+37}   - 1]\); 32 bits.
-#if defined _R16P
+#if defined _real128
 #if defined _R_P_IS_R16P
 integer, parameter :: R_P  = R16P                        !< Default real precision.
 #endif
@@ -60,14 +60,14 @@ integer, parameter :: I1P = selected_int_kind(2)  !< Range \([-2^{7} ,+2^{7}  - 
 integer, parameter :: I_P = I4P                   !< Default integer precision.
 
 ! format parameters
-#if defined _R16P
+#if defined _real128
 character(*), parameter :: FR16P = '(E42.33E4)' !< Output format for kind=R16P real.
 #else
 character(*), parameter :: FR16P = '(E23.15E3)' !< Output format for kind=R8P real.
 #endif
 character(*), parameter :: FR8P  = '(E23.15E3)' !< Output format for kind=R8P real.
 character(*), parameter :: FR4P  = '(E13.6E2)'  !< Output format for kind=R4P real.
-#if defined _R16P
+#if defined _real128
 #if defined _R_P_IS_R16P
 character(*), parameter :: FR_P  = FR16P        !< Output format for kind=R_P real.
 #endif
@@ -92,14 +92,14 @@ character(*), parameter :: FI_P   = FI4P       !< Output format for kind=I_P int
 character(*), parameter :: FI_PZP = FI4PZP     !< Output format for kind=I_P integer with zero prefixing.
 
 ! length (number of digits) of formatted numbers
-#if defined _R16P
+#if defined _real128
 integer, parameter :: DR16P = 42    !< Number of digits of output format FR16P.
 #else
 integer, parameter :: DR16P = 23    !< Number of digits of output format FR8P.
 #endif
 integer, parameter :: DR8P  = 23    !< Number of digits of output format FR8P.
 integer, parameter :: DR4P  = 13    !< Number of digits of output format FR4P.
-#if defined _R16P
+#if defined _real128
 #if defined _R_P_IS_R16P
 integer, parameter :: DR_P  = DR16P !< Number of digits of output format FR_P.
 #endif
@@ -120,12 +120,12 @@ integer, parameter :: DI_P  = DI4P !< Number of digits of output format I_P.
 
 ! list of kinds
 integer,      parameter :: CHARACTER_KINDS_LIST(1:3) = [ASCII, UCS4, CK]                        !< List of character kinds.
-#if defined _R16P
+#if defined _real128
 integer,      parameter :: REAL_KINDS_LIST(1:4)      = [R16P, R8P, R4P, R_P]                    !< List of real kinds.
 #else
 integer,      parameter :: REAL_KINDS_LIST(1:3)      = [R8P, R4P, R_P]                    !< List of real kinds.
 #endif
-#if defined _R16P
+#if defined _real128
 character(*), parameter :: REAL_FORMATS_LIST(1:4)    = [FR16P, FR8P, FR4P//' ', FR_P]           !< List of real formats.
 #else
 character(*), parameter :: REAL_FORMATS_LIST(1:3)    = [FR8P, FR4P//' ', FR_P]           !< List of real formats.
@@ -134,7 +134,7 @@ integer,      parameter :: INTEGER_KINDS_LIST(1:5)   = [I8P, I4P, I2P, I1P,I_P] 
 character(*), parameter :: INTEGER_FORMATS_LIST(1:5) = [FI8P, FI4P, FI2P//' ', FI1P//' ', FI_P] !< List of integer formats.
 
 ! minimum and maximum (representable) values
-#if defined _R16P
+#if defined _real128
 real(R16P),   parameter :: MinR16P = -huge(1._R16P) !< Minimum value of kind=R16P real.
 real(R16P),   parameter :: MaxR16P =  huge(1._R16P) !< Maximum value of kind=R16P real.
 #else
@@ -159,7 +159,7 @@ integer(I1P), parameter :: MaxI1P  =  huge(1_I1P)   !< Maximum value of kind=I1P
 integer(I_P), parameter :: MaxI_P  =  huge(1_I_P)   !< Maximum value of kind=I_P integer.
 
 ! real smallest (representable) values
-#if defined _R16P
+#if defined _real128
 real(R16P), parameter :: smallR16P = tiny(1._R16P) !< Smallest representable value of kind=R16P real.
 #else
 real(R8P),  parameter :: smallR16P = tiny(1._R8P ) !< Smallest representable value of kind=R8P real.
@@ -169,7 +169,7 @@ real(R4P),  parameter :: smallR4P  = tiny(1._R4P ) !< Smallest representable val
 real(R_P),  parameter :: smallR_P  = tiny(1._R_P ) !< Smallest representable value of kind=R_P real.
 
 ! smallest real representable difference by the running calculator
-#if defined _R16P
+#if defined _real128
 real(R16P), parameter :: ZeroR16P = nearest(1._R16P, 1._R16P) - &
                                     nearest(1._R16P,-1._R16P) !< Smallest representable difference of kind=R16P real.
 #else
@@ -184,7 +184,7 @@ real(R_P),  parameter :: ZeroR_P  = 0._R_P !nearest(1._R_P, 1._R_P) - &
                                     !nearest(1._R_P,-1._R_P)   !< Smallest representable difference of kind=R_P real.
 
 ! bits/bytes memory requirements
-#if defined _R16P
+#if defined _real128
 integer(I2P), parameter :: BIR16P = storage_size(MaxR16P)      !< Number of bits of kind=R16P real.
 #else
 integer(I1P), parameter :: BIR16P = storage_size(MaxR8P)       !< Number of bits of kind=R8P real.
@@ -192,7 +192,7 @@ integer(I1P), parameter :: BIR16P = storage_size(MaxR8P)       !< Number of bits
 integer(I1P), parameter :: BIR8P  = storage_size(MaxR8P)       !< Number of bits of kind=R8P real.
 integer(I1P), parameter :: BIR4P  = storage_size(MaxR4P)       !< Number of bits of kind=R4P real.
 integer(I1P), parameter :: BIR_P  = storage_size(MaxR_P)       !< Number of bits of kind=R_P real.
-#if defined _R16P
+#if defined _real128
 integer(I2P), parameter :: BYR16P = BIR16P/8_I2P               !< Number of bytes of kind=R16P real.
 #else
 integer(I1P), parameter :: BYR16P = BIR8P/8_I1P                !< Number of bytes of kind=R8P real.

--- a/src/lib/penf_stringify.F90
+++ b/src/lib/penf_stringify.F90
@@ -38,7 +38,7 @@ endinterface
 interface str
   !< Convert number (real and integer) to string (number to string type casting).
   module procedure                       &
-#if defined _R16P
+#if defined _real128
                    strf_R16P,str_R16P,   &
 #endif
                    strf_R8P ,str_R8P,    &
@@ -48,7 +48,7 @@ interface str
                    strf_I2P ,str_I2P,    &
                    strf_I1P ,str_I1P,    &
                              str_bol,    &
-#if defined _R16P
+#if defined _real128
                              str_a_R16P, &
 #endif
                              str_a_R8P,  &
@@ -67,7 +67,7 @@ endinterface
 interface cton
   !< Convert string to number (real and integer, string to number type casting).
   module procedure            &
-#if defined _R16P
+#if defined _real128
                    ctor_R16P, &
 #endif
                    ctor_R8P,  &
@@ -81,7 +81,7 @@ endinterface
 interface bstr
   !< Convert number (real and integer) to bit-string (number to bit-string type casting).
   module procedure            &
-#if defined _R16P
+#if defined _real128
                    bstr_R16P, &
 #endif
                    bstr_R8P,  &
@@ -95,7 +95,7 @@ endinterface
 interface bcton
   !< Convert bit-string to number (real and integer, bit-string to number type casting).
   module procedure             &
-#if defined _R16P
+#if defined _real128
                    bctor_R16P, &
 #endif
                    bctor_R8P,  &


### PR DESCRIPTION
In order to make the macro more self-explanatory and to make it closer to iso_fortran_env module, I redefined the macro _R16P to _real128