### PR TITLE
Fix: guard quad-precision bit-string routines behind _R16P

### DIFF
--- a/src/lib/penf_stringify.F90
+++ b/src/lib/penf_stringify.F90
@@ -1212,6 +1212,7 @@ contains
    if (present(error)) error = err
    endfunction ctoi_I1P
 
+#if defined _R16P
    elemental function bstr_R16P(n) result(bstr)
    !< Convert real to string of bits.
    !<
@@ -1231,6 +1232,7 @@ contains
    buffer = transfer(n, buffer)
    write(bstr, '(16B8.8)') buffer
    endfunction bstr_R16P
+#endif
 
    elemental function bstr_R8P(n) result(bstr)
    !< Convert real to string of bits.
@@ -1332,6 +1334,7 @@ contains
    write(bstr, '(B8.8)') n
    endfunction bstr_I1P
 
+#if defined _R16P
    elemental function bctor_R16P(bstr, knd) result(n)
    !< Convert bit-string to real.
    !<
@@ -1349,6 +1352,7 @@ contains
    read(bstr, '(16B8.8)') buffer
    n = transfer(buffer, n)
    endfunction bctor_R16P
+#endif
 
    elemental function bctor_R8P(bstr, knd) result(n)
    !< Convert bit-string to real.


### PR DESCRIPTION
  Compile the R16P bit-string conversion routines (bstr_R16P, bctor_R16P)
  only when the _R16P macro is defined, mirroring the guards already present
  on their generic-interface entries (bstr / bcton).
  Problem
  -------
  The generic interfaces add bstr_R16P / bctor_R16P only under
  `#if defined _R16P`, but their function *bodies* were compiled
  unconditionally. When _R16P is not defined, R16P collapses to
  selected_real_kind(15,307) (a 64-bit, 8-byte real), yet bstr_R16P still
  declares `integer(I1P) :: buffer(16)` and assigns
      buffer = transfer(n, buffer)
  The transfer of an 8-byte source yields a result of extent 8, while the
  left-hand side has extent 16. This is a non-conforming array assignment.
  gfortran, nvfortran and ifort/ifx silently tolerate the mismatch, so the
  defect went unnoticed. LLVM Flang (incl. AMD's amdflang / flang-23), which
  performs stricter semantic analysis, correctly rejects it:
      error: Dimension 1 of left-hand side has extent 16,
             but right-hand side has extent 8
          buffer = transfer(n, buffer)
  This breaks any PENF build with amdflang/flang when _R16P is not enabled
  (the default).
  Fix
  ---
  Wrap the bodies of bstr_R16P and bctor_R16P in `#if defined _R16P` /
  `#endif`. The routines are private and reachable only via the bstr / bcton
  generics, which already exclude them when _R16P is undefined, so they are
  dead code in that configuration. No behavior change for any compiler when
  _R16P is defined or undefined; this only stops the unused, ill-formed code
  from being presented to the front end.
  bstr_R8P/bstr_R4P (and the I*P variants) are unaffected: their buffer sizes
  (8 and 4 bytes) already match their kinds.